### PR TITLE
Remove references to deprecated rules formatting

### DIFF
--- a/docs/gh/configs/config-file-overview.md
+++ b/docs/gh/configs/config-file-overview.md
@@ -16,10 +16,10 @@ The `.recurseml.yaml` config file allows you to customize how RML analyzes your 
 
 The config file currently supports the following keys:
 
-| Key                    | Type            | Required | Default | Description                                       |
-| ---------------------- | --------------- | -------- | ------- | ------------------------------------------------- |
-| `report_status_checks` | boolean         | No       | `false` | Whether to report results as GitHub status checks |
-| `rules`                | list of objects | No       | `[]`    | Rules for targeting specific files                |
+| Key                    | Type                   | Required | Default | Description                                       |
+| ---------------------- | ---------------------- | -------- | ------- | ------------------------------------------------- |
+| `report_status_checks` | boolean                | No       | `false` | Whether to report results as GitHub status checks |
+| `rules`                | string or list of strings | No       | `[]`    | Path(s) to rule directories                       |
 
 ## Report Status Checks
 
@@ -29,7 +29,7 @@ To learn more about this feature, see the [Report Status Checks documentation](.
 
 ## Rules
 
-The `rules` setting allows you to define rules that apply only to certain files or file types using glob patterns. Each rule consists of a name, a description, and a list of file match patterns.
+The `rules` setting allows you to specify directories containing rule files in `.mdc` format. Each rule file can define custom checks and constraints for your codebase.
 
 To learn how to define and use these rules, see the [Rules documentation](./rules.mdx).
 
@@ -38,12 +38,13 @@ To learn how to define and use these rules, see the [Rules documentation](./rule
 ```yaml
 report_status_checks: true
 
-rules:
-  - name: "require-todo-comments-to-have-ticket-id"
-    applicable_files:
-      - "*.py"
-      - "*.ts"
-    description: "All TODO comments must include a reference to a ticket ID (e.g., TODO: REFACTOR X-12345 - fix loop)"
+# Single rules directory
+rules: .rules/
+
+# Or multiple directories
+# rules:
+#   - .rules/clean_code/
+#   - .project_rules/
 ```
 
 ## Error Handling

--- a/docs/gh/configs/config-file-overview.md
+++ b/docs/gh/configs/config-file-overview.md
@@ -16,10 +16,10 @@ The `.recurseml.yaml` config file allows you to customize how RML analyzes your 
 
 The config file currently supports the following keys:
 
-| Key                    | Type                   | Required | Default | Description                                       |
-| ---------------------- | ---------------------- | -------- | ------- | ------------------------------------------------- |
-| `report_status_checks` | boolean                | No       | `false` | Whether to report results as GitHub status checks |
-| `rules`                | string or list of strings | No       | `[]`    | Path(s) to rule directories                       |
+| Key                    | Type                | Required | Default | Description                                       |
+| ---------------------- | ------------------- | -------- | ------- | ------------------------------------------------- |
+| `report_status_checks` | boolean             | No       | `false` | Whether to report results as GitHub status checks |
+| `rules`                | string  \| string[] | No       | `[]`    | Path(s) to rule directories                       |
 
 ## Report Status Checks
 
@@ -29,7 +29,7 @@ To learn more about this feature, see the [Report Status Checks documentation](.
 
 ## Rules
 
-The `rules` setting allows you to specify directories containing rule files in `.mdc` format. Each rule file can define custom checks and constraints for your codebase.
+The `rules` setting allows you to specify directories containing rule files in the `.mdc` format. Each rule file can define custom checks and constraints for your codebase.
 
 To learn how to define and use these rules, see the [Rules documentation](./rules.mdx).
 

--- a/docs/gh/configs/report-status-checks.md
+++ b/docs/gh/configs/report-status-checks.md
@@ -26,21 +26,20 @@ When `report_status_checks` is enabled:
 
 ## Compatibility
 
-This setting works independently of other configuration options. You can use it alongside `rules` or with the default RML behavior.
+This setting works independently of other configuration options. You can use it alongside custom [rules](/gh/configs/rules) or with the default RML behavior.
 
 ## Example
 
 ```yaml
 report_status_checks: true
 
-rules:
-  - name: "no-todo-comments"
-    applicable_files:
-      - "*.js"
-    description: "Disallow TODO comments in production code"
+# Rules directory containing .mdc files
+rules: .rules/
 ```
 
-With this configuration, any bugs or violations of the rule will trigger a failed status check on the pull request.
+With this configuration, any bugs detected by RML or violations of custom rules will trigger a failed status check on the pull request.
+
+For more information on creating custom rules, see the [Rules documentation](/gh/configs/rules).
 
 ## Default Behavior
 

--- a/docs/gh/index.mdx
+++ b/docs/gh/index.mdx
@@ -35,6 +35,12 @@ Once installed, the app will be active on the selected repositories.
 
 After installing the Recurse ML GitHub App, you can start using it immediately. Just go ahead and create a new pull request in any of the repositories where the app is installed. After about a minute of processing, Recurse ML will return the analysis results.
 
+## 3. Optional: Configure Custom Rules
+
+Want to enforce project-specific conventions? You can create custom rules to check for coding standards, naming patterns, or highlight sensitive areas that need extra attention.
+
+To get started with custom rules, see the [Rules documentation](/gh/configs/rules).
+
 ---
 
-🎉 That’s it! Recurse ML is now monitoring your pull requests and helping catch bugs before they reach production.
+🎉 That's it! Recurse ML is now monitoring your pull requests and helping catch bugs before they reach production.

--- a/docs/gh/installation.md
+++ b/docs/gh/installation.md
@@ -40,3 +40,11 @@ You do not need to run any CLI tools or configure CI workflows. Everything is ha
 ***
 
 🎉 Recurse ML is now installed and ready to start reviewing pull requests in your repository!
+
+## Next Steps
+
+Once you have Recurse ML up and running, you may want to:
+
+- Create custom [rules](/gh/configs/rules) to enforce project-specific coding standards
+- Configure [status checks](/gh/configs/report-status-checks) to integrate with your workflow
+- Review the complete [configuration options](/gh/configs/config-file-overview)

--- a/docs/rml/cli-reference.md
+++ b/docs/rml/cli-reference.md
@@ -49,3 +49,13 @@ Compare changes to `file.py` between the `main` and `feature` branches.
 | `-md`, `--markdown` | Outputs results in markdown format. Ideal for LLM or programmatic use.        |
 
 You can combine these flags to tailor how RML analyzes your changes and how the results are formatted.
+
+---
+
+## Configuration
+
+RML supports project-specific configuration through `.recurseml.yaml` files. You can use configuration to define custom rules that enforce coding standards and project conventions.
+
+For detailed information about configuration options, see the [Config File Overview](/rml/configs/config-file-overview).
+
+To learn about creating custom rules, see the [Rules documentation](/rml/configs/rules).

--- a/docs/rml/configs/config-file-overview.md
+++ b/docs/rml/configs/config-file-overview.md
@@ -16,13 +16,13 @@ The `.recurseml.yaml` config file allows you to customize how RML analyzes your 
 
 The config file currently supports the following key(s):
 
-| Key     | Type                   | Required | Default | Description                        |
-| ------- | ---------------------- | -------- | ------- | ---------------------------------- |
-| `rules` | string or list of strings | No       | `[]`    | Path(s) to rule directories |
+| Key     | Type                 | Required | Default | Description                 |
+| ------- | -------------------- | -------- | ------- | --------------------------- |
+| `rules` | `string` \| string[] | No       | `[]`    | Path(s) to rule directories |
 
 ## Rules
 
-The `rules` setting allows you to specify directories containing rule files in `.mdc` format. Each rule file can define custom checks and constraints for your codebase.
+The `rules` setting allows you to specify directories containing rule files in the `.mdc` format. Each rule file can define custom checks and constraints for your codebase.
 
 To learn how to define and use these rules, see the [Rules documentation](./rules.mdx).
 

--- a/docs/rml/configs/config-file-overview.md
+++ b/docs/rml/configs/config-file-overview.md
@@ -16,25 +16,26 @@ The `.recurseml.yaml` config file allows you to customize how RML analyzes your 
 
 The config file currently supports the following key(s):
 
-| Key     | Type            | Required | Default | Description                        |
-| ------- | --------------- | -------- | ------- | ---------------------------------- |
-| `rules` | list of objects | No       | `[]`    | Rules for targeting specific files |
+| Key     | Type                   | Required | Default | Description                        |
+| ------- | ---------------------- | -------- | ------- | ---------------------------------- |
+| `rules` | string or list of strings | No       | `[]`    | Path(s) to rule directories |
 
 ## Rules
 
-The `rules` setting allows you to define rules that apply only to certain files or file types using glob patterns. Each rule consists of a name, a description, and a list of file match patterns.
+The `rules` setting allows you to specify directories containing rule files in `.mdc` format. Each rule file can define custom checks and constraints for your codebase.
 
 To learn how to define and use these rules, see the [Rules documentation](./rules.mdx).
 
 ## Example Configuration
 
 ```yaml
+# Single rules directory
+rules: .rules/
+
+# Or multiple directories
 rules:
-  - name: "require-todo-comments-to-have-ticket-id"
-    applicable_files:
-      - "*.py"
-      - "*.ts"
-    description: "All TODO comments must include a reference to a ticket ID (e.g., TODO: REFACTOR X-12345 - fix loop)"
+  - .rules/clean_code/
+  - .project_rules/
 ```
 
 ## Error Handling

--- a/docs/rml/getting-started/installing-on-linux.md
+++ b/docs/rml/getting-started/installing-on-linux.md
@@ -27,6 +27,14 @@ rml --version
 
 If the command returns `🐞 Running rml version {version}`, RML has been installed successfully and is ready to use.
 
+## Next Steps
+
+Now that RML is installed, you can:
+
+- Check out the [Quickstart guide](/rml/) to run your first analysis
+- Learn about [configuration options](/rml/configs/config-file-overview) 
+- Create custom [rules](/rml/configs/rules) for your project
+
 ## Troubleshooting
 
 If you encounter any issues during installation, please check out the [help and support](../help-and-support.mdx) section.

--- a/docs/rml/getting-started/installing-on-macos.md
+++ b/docs/rml/getting-started/installing-on-macos.md
@@ -26,6 +26,14 @@ rml --version
 
 If the command returns `🐞 Running rml version {version}`, RML has been installed successfully and is ready to use.
 
+## Next Steps
+
+Now that RML is installed, you can:
+
+- Check out the [Quickstart guide](/rml/) to run your first analysis
+- Learn about [configuration options](/rml/configs/config-file-overview) 
+- Create custom [rules](/rml/configs/rules) for your project
+
 ## Troubleshooting
 
 If you encounter any issues during installation, please check out the [help and support](../help-and-support.mdx) section.

--- a/docs/rml/index.mdx
+++ b/docs/rml/index.mdx
@@ -58,4 +58,10 @@ rml path/to/your/file.js
 
 By default rml analyzes unstaged changes (i.e. the ones displayed by `git diff` without any arguments).
 
+## 4. Optional: Configure Custom Rules
+
+Want to enforce project-specific conventions? You can create custom rules to check for coding standards, naming patterns, or highlight sensitive areas that need extra attention.
+
+To get started with custom rules, see the [Rules documentation](/rml/configs/rules).
+
 🎉 That's it! You're now ready to start using RML to catch bugs early in your development process.


### PR DESCRIPTION
Our docs still contained references to our deprecated rule format (i.e. in-line in the `.recurseml.yaml` file). This PR replaces these with the cursor-style rules support