### PR TITLE
Move recurse prompt section before configure claude code

### DIFF
--- a/docs/remcp/index.mdx
+++ b/docs/remcp/index.mdx
@@ -25,7 +25,14 @@ curl -sSL https://storage.googleapis.com/remcp/install.sh | bash
 
 # Usage tips:
 
-## Configure claude code (recommended)
+## Recurse prompt (recommended)
+
+```
+$ /recurse:review_code Please implement access control on web api endpoints
+```
+The prompt is automatically available once you install remcp, and claude will start using Recurse MCP for code changes.
+
+## Configure claude code
 
 ```bash
 remcp configure claude
@@ -37,14 +44,6 @@ If you are not happy with the global setting, you can remove it using the follow
 ```bash
 remcp configure claude --remove
 ```
-
-## Recurse prompt
-
-```
-# In claude code
-$ /recurse:review_code Please implement access control on web api endpoints
-```
-The prompt is automatically available once you install remcp, and claude will start using Recurse MCP for code changes.
 
 
 ## Project level configuration (manual)

--- a/docs/remcp/index.mdx
+++ b/docs/remcp/index.mdx
@@ -28,6 +28,7 @@ curl -sSL https://storage.googleapis.com/remcp/install.sh | bash
 ## Recurse prompt (recommended)
 
 ```
+# In claude code
 $ /recurse:review_code Please implement access control on web api endpoints
 ```
 The prompt is automatically available once you install remcp, and claude will start using Recurse MCP for code changes.


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR reorganizes the documentation by moving the "Recurse prompt" section to appear before the "Configure claude code" section in the remcp usage documentation. The content itself remains unchanged, only the ordering of the sections has been adjusted to improve the flow of the documentation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/remcp/index.mdx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/781108bdb778587d31d88f31bc4cd0ea0fd6dec58bde938e35b48eabcca6323d/?repo_owner=Recurse-ML&repo_name=docs&pr_number=15)
<!-- RECURSEML_SUMMARY:END -->