### PR TITLE
Fix spx Linux x64 url

### DIFF
--- a/docs/spx/index.mdx
+++ b/docs/spx/index.mdx
@@ -25,7 +25,7 @@ Before using spx, ensure you have:
 
 Download the appropriate binary for your system architecture:
 
-- **Linux x64:** [linux-x64](https://storage.googleapis.com/docs-recurse-ml/spx/spx-darwin-x64/spx)
+- **Linux x64:** [linux-x64](https://storage.googleapis.com/docs-recurse-ml/spx/spx-linux-x64/spx)
 - **Linux ARM64:** [linux-arm64](https://storage.googleapis.com/docs-recurse-ml/spx/spx-linux-arm64/spx)
 - **Linux x64 (musl):** [linux-x64-musl](https://storage.googleapis.com/docs-recurse-ml/spx/spx-linux-x64-musl/spx)
 - **Linux ARM64 (musl):** [linux-arm64-musl](https://storage.googleapis.com/docs-recurse-ml/spx/spx-linux-arm64-musl/spx)


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a documentation error in the download URL for the Linux x64 binary. The URL was incorrectly pointing to `spx-darwin-x64` (macOS) instead of `spx-linux-x64` (Linux).

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/spx/index.mdx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/ea6693cf7cfbbcceab235cc0c6d5e3b4dddb5a850f92306cb24b695c5eea14be/?repo_owner=Recurse-ML&repo_name=docs&pr_number=17)
<!-- RECURSEML_SUMMARY:END -->