### PR TITLE
Change installation URL for remcp

### DIFF
--- a/docs/remcp/index.mdx
+++ b/docs/remcp/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 0
 
 **One-line install (macOS and Linux)**
 ```
-curl -sSL https://storage.googleapis.com/remcp/install.sh | bash
+curl -sSL remcp.recurse.ml | bash
 ```
 📝 Next steps:
 1. Make sure `$HOME/.local/bin` is in your `PATH`. Add to `~/.bashrc` or `~/.zshrc`: 

--- a/docs/remcp/index.mdx
+++ b/docs/remcp/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 0
 
 **One-line install (macOS and Linux)**
 ```
-curl -sSL remcp.recurse.ml | bash
+curl -L remcp.recurse.ml | bash
 ```
 📝 Next steps:
 1. Make sure `$HOME/.local/bin` is in your `PATH`. Add to `~/.bashrc` or `~/.zshrc`: 


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the installation URL for remcp from a Google Cloud Storage endpoint to a shorter custom domain (`remcp.recurse.ml`). The change simplifies the installation command while maintaining the same functionality.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/remcp/index.mdx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/5b213b5e426456d3ca12ec987bcb7732beb414f7708dba7f76c62497e91e88b5/?repo_owner=Recurse-ML&repo_name=docs&pr_number=18)
<!-- RECURSEML_SUMMARY:END -->