### PR TITLE
remcp: install claude code: remove mention of session hooks

### DIFF
--- a/docs/remcp/installation/install-claude-code.mdx
+++ b/docs/remcp/installation/install-claude-code.mdx
@@ -19,11 +19,11 @@ claude mcp add recurse --scope user -- remcp serve
 remcp configure claude
 ```
 
-This installs instructions that reminds Claude to use remcp. This is a global configuration for Claude.
+This installs a global rule in your CLAUDE.md file that ensures Claude Code uses remcp automatically.
 
 ## Removing the Configuration
 
-If you are not happy with the instructions, you can remove it using:
+If you want to remove the global rule and prefer to call remcp directly, you can run the following command:
 
 ```bash
 remcp configure --remove claude

--- a/docs/remcp/installation/install-claude-code.mdx
+++ b/docs/remcp/installation/install-claude-code.mdx
@@ -12,18 +12,18 @@ sidebar_position: 1
 claude mcp add recurse --scope user -- remcp serve
 ```
 
-## Step 2: Install hooks
+## Step 2: Configure CLAUDE.md
 
 
 ```bash
 remcp configure claude
 ```
 
-This installs a SessionStart hook that automatically reminds Claude to use remcp. This is a global configuration for Claude.
+This installs instructions that reminds Claude to use remcp. This is a global configuration for Claude.
 
 ## Removing the Configuration
 
-If you are not happy with the hook, you can remove it using:
+If you are not happy with the instructions, you can remove it using:
 
 ```bash
 remcp configure --remove claude


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Updates documentation to clarify that the `remcp configure claude` command installs instructions via CLAUDE.md rather than session hooks. The changes replace all mentions of "hooks" and "SessionStart hook" with more accurate terminology describing the instruction-based configuration approach.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/remcp/installation/install-claude-code.mdx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyzing latest changes...](https://img.shields.io/badge/Analyzing%20latest%20changes...-lightgray?style=plastic)](https://github.com/Recurse-ML/docs/pull/23)
<!-- RECURSEML_SUMMARY:END -->