### PR TITLE
remove remcp configure claude from docs

### DIFF
--- a/docs/remcp/index.mdx
+++ b/docs/remcp/index.mdx
@@ -30,10 +30,10 @@ remcp auth
 
 # Usage tips
 
-### Recurse prompt (recommended)
+### REMCP prompt (recommended)
 
 ```
 # In claude code
-$ /recurse:review_code Please implement access control on web api endpoints
+$ /remcp:review_code Please implement access control on web api endpoints
 ```
-The prompt is automatically available once you install remcp, and claude will start using Recurse MCP for analyzing code changes.
+The prompt is automatically available once you install remcp, and claude will start using REMCP for analyzing code changes.

--- a/docs/remcp/installation/install-claude-code.mdx
+++ b/docs/remcp/installation/install-claude-code.mdx
@@ -5,27 +5,10 @@ sidebar_position: 1
 ---
 # Install in Claude Code
 
-## Step 1: Add MCP to claude
+## Add MCP to claude
 
 
 ```
-claude mcp add recurse --scope user -- remcp serve
-```
-
-## Step 2: Configure CLAUDE.md
-
-
-```bash
-remcp configure claude
-```
-
-This installs a global rule in your CLAUDE.md file that ensures Claude Code uses remcp automatically.
-
-## Removing the Configuration
-
-If you want to remove the global rule and prefer to call remcp directly, you can run the following command:
-
-```bash
-remcp configure --remove claude
+claude mcp add remcp --scope user -- remcp serve
 ```
 

--- a/docs/remcp/installation/install-cursor.mdx
+++ b/docs/remcp/installation/install-cursor.mdx
@@ -32,18 +32,18 @@ alwaysApply: true
 description: Use REMCP to verify your work. Before making changes, call init() on the project if not already done. Once all changes are done, call check() to get bug reports.
 ---
 
-> **Note:** Rules in this section are managed by Recurse ML. Any changes made will be overwritten when pulling new rule updates.
+> **Note:** Rules in this section are managed by REMCP. Any changes made will be overwritten when pulling new rule updates.
 
-# Verify Changes Using Recurse ML MCP
+# Verify Changes Using REMCP
 
 Use REMCP to verify your work while completing tasks. Before making any changes, call `init()` on the project if not already done. Once all changes are done, call `check()` to get bug reports.
 
 ## Do
 
-1. Call `mcp_recurse_init()` before making changes to initialize the project for analysis.
-2. Call `mcp_recurse_check()` after completing your changes to get bug reports.
+1. Call `mcp_remcp_init()` before making changes to initialize the project for analysis.
+2. Call `mcp_remcp_check()` after completing your changes to get bug reports.
 3. Investigate the bug reports and fix valid issues.
-4. Use `mcp_recurse_ignore_issue()` if you're aware of an issue but choose not to address it.
+4. Use `mcp_remcp_ignore_issue()` if you're aware of an issue but choose not to address it.
 
 ## Don't
 
@@ -56,18 +56,18 @@ Use REMCP to verify your work while completing tasks. Before making any changes,
 
 The REMCP provides the following tools:
 
-- `mcp_recurse_init(repo_path)`: Initialize a codebase for analysis. Sets up the project for continuous analysis by performing health checks, creating a project entry in the database, and starting the background worker (if not already running).
+- `mcp_remcp_init(repo_path)`: Initialize a codebase for analysis. Sets up the project for continuous analysis by performing health checks, creating a project entry in the database, and starting the background worker (if not already running).
 
-- `mcp_recurse_check(project_id)`: Check the status of the latest analysis and retrieve any issues found. This should be fast (<1s) as it just reads from the database. The tool might report that an analysis is pending, which means you need to call it again in some time until it says that the analysis either succeeded or errored out.
+- `mcp_remcp_check(project_id)`: Check the status of the latest analysis and retrieve any issues found. This should be fast (<1s) as it just reads from the database. The tool might report that an analysis is pending, which means you need to call it again in some time until it says that the analysis either succeeded or errored out.
 
-- `mcp_recurse_ignore_issue(issue_id)`: Indicate that you're aware of an issue but choose not to address it.
+- `mcp_remcp_ignore_issue(issue_id)`: Indicate that you're aware of an issue but choose not to address it.
 
-- `mcp_recurse_doctor()`: Run diagnostic checks to troubleshoot installation and configuration issues.
+- `mcp_remcp_doctor()`: Run diagnostic checks to troubleshoot installation and configuration issues.
 
 ## Workflow
 
-1. **Before making changes**: Call `mcp_recurse_init()` with the absolute path to the repository root.
-2. **After completing changes**: Call `mcp_recurse_check()` with the project_id returned from init().
+1. **Before making changes**: Call `mcp_remcp_init()` with the absolute path to the repository root.
+2. **After completing changes**: Call `mcp_remcp_check()` with the project_id returned from init().
 3. **If bugs are found**: Review the bug reports, verify whether they are valid, and fix them.
 4. **If analysis is pending**: Wait a moment and call `check()` again until the analysis completes.
 5. **When making a code change**: Clearly state that the change is being made as a result of a bug found by REMCP and state what the bug is.


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes the `remcp configure claude` command and related documentation, simplifying the Claude Code installation process. The changes eliminate the second step that previously added a global rule to CLAUDE.md file, streamlining the setup to just a single MCP installation command. Additionally, the PR updates branding and terminology throughout the documentation, replacing references to "Recurse" with "REMCP" and correcting tool function names to use the `mcp_remcp_*` prefix consistently.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/remcp/installation/install-claude-code.mdx` |
| 2 | `docs/remcp/index.mdx` |
| 3 | `docs/remcp/installation/install-cursor.mdx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/6ddb0434a64ae13bbb568b4d25179004fdf50417e3be0b56d75a4a69c0d6b60e/?repo_owner=Recurse-ML&repo_name=docs&pr_number=24)
<!-- RECURSEML_SUMMARY:END -->